### PR TITLE
NSM client naming in alsaMidi context

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,6 +65,7 @@
 #endif
 #include <QLocale>
 #include <QLibraryInfo>
+#include <unistd.h>
 
 #include "mainwindow.h"
 #include "main.h"

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1417,6 +1417,9 @@ int MainWindow::nsm_open(const char *name, const char *display_name, const char 
         engine->driver->callJack(-1);
         engine->driver->callJack(engine->getPortCount(), client_id);
     }
+    else {
+        snd_seq_set_client_name(engine->driver->getClientId(), client_id);
+    }
     configFile.append(".qmax");
     emit nsmOpenFile(configFile);
     return ERR_OK;


### PR DESCRIPTION
Hi Frank, just tried to make it possible to have NSM naming when chosing alsaMidi backend. I think the code might work, I managed to built it (had to dig into the config and makefile, in which there are things that I suspect to be hardwritten), but never could install it, so not able to test it with NSM (at least the -a option didn't work anymore...). I can work on ita bit more if needed, but would have to get it possible to compile/install, and by now I don't feel the INSTALL and README files are in adequation with qmake and such.