### PR TITLE
add NSM keys to .desktop file

### DIFF
--- a/qmidiarp.desktop
+++ b/qmidiarp.desktop
@@ -18,5 +18,7 @@ Icon=qmidiarp
 MimeType=application/qma;application/qmax;
 Exec=qmidiarp %F
 TryExec=qmidiarp
+X-NSM-Capable=true
+X-NSM-Exec=qmidiarp
 Terminal=false
 StartupNotify=true


### PR DESCRIPTION
This adds NSM related keys to the xdg .desktop file, so NSM related tools can find applications with NSM support. 

X-NSM-Capable=true
X-NSM-Exec=qmidiarp

X-NSM-Capable should be ideally be false if the application is build without NSM support.
X-NSM-Exec, is the exec name of the application when used in NSM. It can't contain a path or command line arguments like %f. 
