### PR TITLE
Add missing unistd.h in src/main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,7 @@
  *
  */
 #include <getopt.h>
+#include <unistd.h>
 #include <QApplication>
 #include <QFileInfo>
 #include <QString>


### PR DESCRIPTION
Fixes: main.cpp: error: getpid was not declared in this scope

Bug: https://bugs.gentoo.org/967521