### PR TITLE
Stable drum gate

### DIFF
--- a/qmidiarp_arp.lv2/qmidiarp_arp.ttl
+++ b/qmidiarp_arp.lv2/qmidiarp_arp.ttl
@@ -369,6 +369,27 @@
         lv2:default 1 ;
         lv2:minimum 0 ;
         lv2:maximum 1 ;
+    ] , [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 32 ;
+        lv2:symbol "DRUM_GATE" ;
+        lv2:name "Drum Gate" ;
+        lv2:portProperty lv2:enumeration, lv2:integer ;
+        lv2:scalePoint [ rdfs:label "Off"; rdf:value 0 ] ;
+        lv2:scalePoint [ rdfs:label "Bass Drum"; rdf:value 1 ] ;
+        lv2:scalePoint [ rdfs:label "Bass + Snare"; rdf:value 2 ] ;
+        lv2:default 0 ;
+        lv2:minimum 0 ;
+        lv2:maximum 2 ;
+    ] , [
+        a lv2:InputPort, lv2:ControlPort ;
+        lv2:index 33 ;
+        lv2:symbol "DRUM_GATE_TIME" ;
+        lv2:name "Drum Gate Time" ;
+        lv2:portProperty lv2:integer ;
+        lv2:default 1 ;
+        lv2:minimum 1 ;
+        lv2:maximum 16 ;
     ] .
 
 #presets

--- a/qmidiarp_arp.lv2/qmidiarp_arp.ttl
+++ b/qmidiarp_arp.lv2/qmidiarp_arp.ttl
@@ -377,10 +377,11 @@
         lv2:portProperty lv2:enumeration, lv2:integer ;
         lv2:scalePoint [ rdfs:label "Off"; rdf:value 0 ] ;
         lv2:scalePoint [ rdfs:label "Bass Drum"; rdf:value 1 ] ;
-        lv2:scalePoint [ rdfs:label "Bass + Snare"; rdf:value 2 ] ;
+        lv2:scalePoint [ rdfs:label "Snare Drum"; rdf:value 2 ] ;
+        lv2:scalePoint [ rdfs:label "Bass + Snare"; rdf:value 3 ] ;
         lv2:default 0 ;
         lv2:minimum 0 ;
-        lv2:maximum 2 ;
+        lv2:maximum 3 ;
     ] , [
         a lv2:InputPort, lv2:ControlPort ;
         lv2:index 33 ;

--- a/src/midiarp.cpp
+++ b/src/midiarp.cpp
@@ -128,6 +128,9 @@ MidiArp::MidiArp()
     lastLatchTick = 0;
     latchDelayTicks = latchDelayMsec * TPQN / 1000;
     trigDelayTicks = 4;
+    m_drumGateMode = 0;
+    m_drumGateTime = 1;
+    m_gateCloseTick = 0;
     
     nextLength = 0;
     Sample sample = {0, 0, 0, false};
@@ -152,11 +155,38 @@ MidiArp::MidiArp()
 
 bool MidiArp::handleEvent(MidiEvent inEv, int64_t tick, int keep_rel)
 {
+    if (inEv.channel == 9) {
+        if (m_drumGateMode != 0) {
+            if (inEv.type == EV_NOTEON && inEv.value > 0) {
+                bool match = false;
+                if (inEv.data == 35 || inEv.data == 36) {
+                    match = true; // Bass drum
+                } else if (m_drumGateMode == 2 && (inEv.data == 38 || inEv.data == 40)) {
+                    match = true; // Snare
+                }
+                if (match) {
+                    m_gateCloseTick = tick + (m_drumGateTime * TPQN / 4);
+                    
+                    // Snap arpeggiator clock to the drum hit
+                    arpTick = tick;
+                    nextTick = tick;
+                }
+            }
+        }
+        // Fix: Intercept Channel 10 entirely to prevent drum events and sequencer 
+        // loop boundaries (e.g. CC 123 All Notes Off) from bleeding into the 
+        // arpeggiator engine when chIn is Omni.
+        return (false);
+    }
+
     if (inEv.channel != chIn && chIn != OMNI) return(true);
-    if ((inEv.type == EV_CONTROLLER) && 
+    if ((inEv.type == EV_CONTROLLER) &&
         ((inEv.data == CT_ALLNOTESOFF) || (inEv.data == CT_ALLSOUNDOFF))) {
-        clearNoteBuffer();
-        return(true); // In case we receive all notes off we still forward
+        // Fix: Do not clear the note buffer here. Sequencers (like Zynthian) 
+        // often send CC 123 when their transport loops. If we clear the buffer, 
+        // it kills keys the user is physically holding, causing the arpeggiator 
+        // to suddenly stop at loop boundaries. Forward the CC to downstream synths instead.
+        return(true);
     }
     if ((inEv.type == EV_CONTROLLER) && (inEv.data == CT_FOOTSW)) {
         setSustain((inEv.value == 127), tick);
@@ -457,6 +487,17 @@ void MidiArp::getNote(int64_t *tick, int64_t note[], int velocity[], int *length
     } while (advancePatternIndex(false) && (gotCC || chordMode || c == ' '));
 
     l1 = 0;
+    
+    // Drum Gate Enforcer
+    if (m_drumGateMode != 0) {
+        if (arpTick >= m_gateCloseTick) {
+            // Close the gate (silence the arpeggiator step)
+            note[0] = -1;
+            velocity[0] = 0;
+            return;
+        }
+    }
+
     if (noteCount) do {
         noteIndex[l1] = (noteCount) ? tmpIndex[l1] % noteCount : 0;
         note[l1] = clip(notes[noteBufPtr][0][noteIndex[l1]] + current_octave * 12

--- a/src/midiarp.cpp
+++ b/src/midiarp.cpp
@@ -159,9 +159,9 @@ bool MidiArp::handleEvent(MidiEvent inEv, int64_t tick, int keep_rel)
         if (m_drumGateMode != 0) {
             if (inEv.type == EV_NOTEON && inEv.value > 0) {
                 bool match = false;
-                if (inEv.data == 35 || inEv.data == 36) {
+                if ((m_drumGateMode == 1 || m_drumGateMode == 3) && (inEv.data == 35 || inEv.data == 36)) {
                     match = true; // Bass drum
-                } else if (m_drumGateMode == 2 && (inEv.data == 38 || inEv.data == 40)) {
+                } else if ((m_drumGateMode == 2 || m_drumGateMode == 3) && (inEv.data == 38 || inEv.data == 40)) {
                     match = true; // Snare
                 }
                 if (match) {

--- a/src/midiarp.h
+++ b/src/midiarp.h
@@ -235,6 +235,9 @@ class MidiArp : public MidiWorker  {
     int octHigh;        /*!< The higher octave limit. @see repeatPatternThroughChord */
 
     uint64_t returnTick; /*!< Holds the time in internal ticks of the currently active arpeggio step */
+    int m_drumGateMode;  /*!< Drum Gate Mode (0=Off, 1=Bass, 2=Bass+Snare) */
+    int m_drumGateTime;  /*!< Drum Gate Time in 1/16th notes (1 to 16) */
+    uint64_t m_gateCloseTick; /*!< Tick when the drum gate closes */
 
   public:
     MidiArp();
@@ -246,6 +249,8 @@ class MidiArp : public MidiWorker  {
     void updateRandomLengthAmp(int);
     void updateAttackTime(int);
     void updateReleaseTime(int);
+    void updateDrumGateMode(int val) { m_drumGateMode = val; }
+    void updateDrumGateTime(int val) { m_drumGateTime = val; }
 /**
  * @brief  calculates the index of the next arpeggio
  * step and revolves it if necessary.

--- a/src/midiarp.h
+++ b/src/midiarp.h
@@ -235,7 +235,7 @@ class MidiArp : public MidiWorker  {
     int octHigh;        /*!< The higher octave limit. @see repeatPatternThroughChord */
 
     uint64_t returnTick; /*!< Holds the time in internal ticks of the currently active arpeggio step */
-    int m_drumGateMode;  /*!< Drum Gate Mode (0=Off, 1=Bass, 2=Bass+Snare) */
+    int m_drumGateMode;  /*!< Drum Gate Mode (0=Off, 1=Bass, 2=Snare, 3=Bass+Snare) */
     int m_drumGateTime;  /*!< Drum Gate Time in 1/16th notes (1 to 16) */
     uint64_t m_gateCloseTick; /*!< Tick when the drum gate closes */
 

--- a/src/midiarp_lv2.cpp
+++ b/src/midiarp_lv2.cpp
@@ -399,6 +399,9 @@ void MidiArpLV2::updateParams()
                     (int)*val[HOST_SPEED],
                     false);
     }
+    
+    updateDrumGateMode((int)*val[DRUM_GATE]);
+    updateDrumGateTime((int)*val[DRUM_GATE_TIME]);
 }
 
 void MidiArpLV2::initTransport()

--- a/src/midiarp_lv2.h
+++ b/src/midiarp_lv2.h
@@ -70,7 +70,9 @@ public:
             HOST_TEMPO = 26,
             HOST_POSITION = 27,
             HOST_SPEED = 28,
-            TEMPO_MODE = 29
+            TEMPO_MODE = 29,
+            DRUM_GATE = 30,
+            DRUM_GATE_TIME = 31
         };
 
         void connect_port(uint32_t port, void *data);
@@ -89,7 +91,7 @@ public:
 
 private:
 
-        float *val[31];
+        float *val[33];
         uint64_t curFrame;
         uint64_t tempoChangeTick;
         uint64_t trStartingTick;


### PR DESCRIPTION
Hello,

I am an engineer in Michigan and love everything music.  I play piano and guitar and wanted a way to have automatic bass accompaniment with drum sequences.   I have extended qmidiarp_arp.lv2 to add a Drum Gate enumeration and a Gate Time that gates the midi output based on Bass, Snare, or both from a General Midi drum sequence on channel 10.   

Note that I use this only with Zynthian so I have not updated the ui_ttl in Qt although I don't think that is necessary for the functionality.

I also have an "Autochord" mode that I am developing which arpeggiates chord sequences for modes with options for 5th, 7ths, and 9ths.  However, the chord model I am using is partly licensed by midibox Torsten Klose, and I haven't gotten his permission to share yet (nor do I know him even though I have built two midibox projects).

Anyway, I wanted to share with the community as this is a very useful extension for me.
Regards,

Scott Rush
scottarush@yahoo.com